### PR TITLE
fix(work.py): changes in validation

### DIFF
--- a/tests/test_work.py
+++ b/tests/test_work.py
@@ -26,10 +26,8 @@ def test_bad_pipeline():
 
 def test_pipeline_reformat():
     """Test that the work object can't be instantiated with empty pipeline."""
-    work = Work(pipeline="sample test", site="local", user="test")
-    assert work.pipeline == "sample-test"
-    work.pipeline = "sample test"
-    assert work.pipeline == "sample-test"
+    with pytest.raises(ValidationError):
+        Work(pipeline="sample test", site="local", user="test")
 
 
 def test_bad_pipeline_char():

--- a/workflow/definitions/work.py
+++ b/workflow/definitions/work.py
@@ -3,7 +3,6 @@
 from json import loads
 from time import time
 from typing import Any, Dict, List, Literal, Optional, Union
-from warnings import warn
 
 from pydantic import (
     AliasChoices,
@@ -308,22 +307,11 @@ class Work(BaseSettings):
         Returns:
             str: Validated pipeline name.
         """
-        original: str = pipeline
-        pipeline = pipeline.lower()
-        pipeline = pipeline.replace(" ", "-")
-        pipeline = pipeline.replace("_", "-")
         for char in pipeline:
             if not char.isalnum() and char not in ["-"]:
                 raise ValueError(
                     "pipeline name can only contain letters, numbers & hyphens."
                 )
-        if original != pipeline:
-            warn(
-                SyntaxWarning(
-                    f"pipeline reformatted {original}->{pipeline} to hyphen-case."
-                ),
-                stacklevel=2,
-            )
         return pipeline
 
     @field_validator("creation")


### PR DESCRIPTION
Fixed Work.pipeline field being reformatted when wrong value was entered, now it raises error. All tests pass.