### PR TITLE
fix(work): increase max timeout from 1 day to 3 days

### DIFF
--- a/tests/test_work.py
+++ b/tests/test_work.py
@@ -108,9 +108,9 @@ def test_validation_after_instantiation():
 
 
 def test_timeout_exceeds_maximum():
-    """Checks if validation works when timeout field is greater than 86400."""
+    """Checks if validation works when timeout field is greater than 259200."""
     with pytest.raises(ValidationError):
-        Work(pipeline="test", site="local", user="test", timeout=86401)
+        Work(pipeline="test", site="local", user="test", timeout=259201)
 
 
 def test_retries_exceeds_maximum():

--- a/workflow/definitions/work.py
+++ b/workflow/definitions/work.py
@@ -257,12 +257,12 @@ class Work(BaseSettings):
     timeout: int = Field(
         default=3600,
         ge=1,
-        le=86400,
+        le=86400 * 3,
         description="""
         Timeout in seconds for the work to finish.
         After the timeout, the work is marked as failed and retried
         if the number of attempts is less than the maximum number of retries.
-        Defaults 3600s (1 hr) with range of [1, 86400] (1s-24hrs).
+        Defaults 3600s (1 hr) with range of [1, 259200] (1s-72hrs).
         """,
         examples=[7200],
     )


### PR DESCRIPTION
Small change to the max timeout for the Work object.

Signed-off-by: Tarik Zegmott <tarik.zegmott@mcgill.ca>