### PR TITLE
99 workflow lifecycle execute argument object has no attribute is flag

### DIFF
--- a/workflow/lifecycle/configure.py
+++ b/workflow/lifecycle/configure.py
@@ -133,19 +133,16 @@ def defaults(func: Callable[..., Any], work: Work) -> Work:
         logger.info(f"click cli detected for func {work.function}")
         # Get default options from the click command
         for parameter in func.params:
-            if (parameter.name not in known) and parameter.default:
-                if parameter.is_flag:  # type: ignore
-                    options[parameter.opts[-1]] = None
+            name_in_cli = parameter.opts[-1]
+            name_in_function = parameter.name
+
+            if name_in_function not in known:
+                if hasattr(parameter, "default"):
+                    options[name_in_cli] = parameter.default
                 else:
-                    options[parameter.opts[-1]] = parameter.default
-            elif parameter.name in known:
-                if parameter.is_flag:
-                    if parameter.default == parameters.get(parameter.name):
-                        options[parameter.opts[-1]] = None
-                else:
-                    options[parameter.opts[-1]] = parameters.get(
-                        parameter.name  # type: ignore
-                    )
+                    options[name_in_cli] = None
+            elif name_in_function in known:
+                options[name_in_cli] = parameters.get(name_in_function)  # type: ignore
         logger.info(f"click cli options: {options}")
         work.parameters = options
     logger.debug(f"work parameters: {work.parameters}")


### PR DESCRIPTION
I'm not sure I understood the changes made here previously with the is_flag checks. Firstly, if the `Parameter` is a `Argument`, it'll thrown an error because `Argument` doesn't have `is_flag`, only `Option` does (`Parameter` can be `Argument` or `Option`). So, one could check with `hasattr` to avoid the error thrown. However, I don't see the point of even checking for `is_flag`. The check that was here actually caused the `Parameter` to be set to `None` if the default value of the `Parameter` was equal to the value of the parameter given in the Work object ---> I don't quite understand where that logic came from.

I don't think `is_flag` changes anything. If the parameter value is not given in the Work object, we should use the default value of the `Parameter`. If it is given, then we just use that value, no? Because right now, for CHAMPSS, any `Option` we have with `is_flag` and no default value (None) is just ignored, since the default value of None is not equal to the value we give it (True/False). Again don't quite understand that previous logic.