### PR TITLE
Remove assigning of "None" to parameters not given, causes TypeError

### DIFF
--- a/workflow/lifecycle/configure.py
+++ b/workflow/lifecycle/configure.py
@@ -139,8 +139,6 @@ def defaults(func: Callable[..., Any], work: Work) -> Work:
             if name_in_function not in known:
                 if hasattr(parameter, "default"):
                     options[name_in_cli] = parameter.default
-                else:
-                    options[name_in_cli] = None
             elif name_in_function in known:
                 options[name_in_cli] = parameters.get(name_in_function)  # type: ignore
         logger.info(f"click cli options: {options}")


### PR DESCRIPTION
My recent PR broke things because it assigns "None" to every parameter in a Click argument/option that was not given in work.parameters. 