### PR TITLE
fix: loki logs in workflow web

### DIFF
--- a/workflow/cli/run.py
+++ b/workflow/cli/run.py
@@ -196,6 +196,29 @@ def run(
         "[bold red]Backend Checks [/bold red]",
         extra=dict(markup=True, color="green"),
     )
+    # Add pipeline and site to loki tags
+    if config.get("logging", {}).get("loki", {}).get("tags", {}):
+        # Loki tags exist, add pipeline and site
+        config["logging"]["loki"]["tags"].update(
+            {
+                # Assumes that there is only one bucket
+                "pipeline": buckets[0],
+                "site": site,
+            }
+        )
+    else:
+        # Missing Logging config in Workspace
+        config.update({
+            "logging": {
+                "loki": {
+                    "tags": {
+                        # Assumes that there is only one bucket
+                        "pipeline": buckets[0],
+                        "site": site,
+                    }
+                }
+            }
+        })
     loki_status: bool = configure.loki(logger=logger, config=config)
     logger.info(f"Loki Logs: {'✅' if loki_status else '❌'}")
     http: HTTPContext = HTTPContext(backends=["buckets"])

--- a/workflow/workspaces/chimefrb.yml
+++ b/workflow/workspaces/chimefrb.yml
@@ -104,3 +104,7 @@ deployers:
   chime:
     docker:
       client_url: tcp://frb-vsop.chime:2375
+
+logging:
+  loki:
+    tags: {}


### PR DESCRIPTION
- fix(workflow-run-loki): add logic to add pipeline and site to the loki tags
- refactor(chimefrb-workspace): add loki tags config to workspace

The issue was that the logs being pushed to Loki were missing tags that are used when searching for the logs in Loki. Notably the pipeline tag was missing. In this PR, pipeline and site are merged in to the Loki tags defined in the Workspace config.
