### PR TITLE
119 fix lifecycle/configure.py's defaults/arguments functions, does not work for @click.argument types

### DIFF
--- a/workflow/lifecycle/configure.py
+++ b/workflow/lifecycle/configure.py
@@ -101,12 +101,16 @@ def arguments(func: Callable[..., Any], work: Work) -> List[str]:
         List[str]: List of CLI arguments
     """
     args: List[str] = []
+
     for parameter in func.params:
         parameter_name_in_cli = parameter.opts[-1]
         paraneter_name_in_function = parameter.name
         parameter_value_in_work = work.parameters.get(paraneter_name_in_function, None)
 
         if parameter_value_in_work:
+            if isinstance(parameter_value_in_work, list):
+                parameter_value_in_work = " ".join(parameter_value_in_work)
+
             if isinstance(parameter, click.Argument):
                 # If argument, then the parameter is purely positional without a key
                 args.append(f"{parameter_value_in_work}")

--- a/workflow/lifecycle/configure.py
+++ b/workflow/lifecycle/configure.py
@@ -111,17 +111,22 @@ def arguments(func: Callable[..., Any], work: Work) -> List[str]:
                 # If argument, then the parameter is purely positional without a key
                 args.append(f"{parameter_value_in_work}")
             elif isinstance(parameter, click.Option):
-                if not parameter_value_in_work:
+                if hasattr(parameter, "is_flag") and parameter.is_flag:
                     # If is_flag=True, then the parameter is a flag and doesn't have a value
                     args.append(f"{parameter_name_in_cli}")
-                elif parameter_value_in_work and len(parameter_name_in_cli) == 2:
-                    # Short options (often denoted by a single hyphen and a single letter like -r)
-                    # are commonly written with a space between the option and its value
-                    args.append(f"{parameter_name_in_cli} {parameter_value_in_work}")
-                elif parameter_value_in_work and len(parameter_name_in_cli) > 2:
-                    # Long options (often denoted by two hyphens and a word like --recursive)
-                    # are commonly written with an equals sign between the option and its value
-                    args.append(f"{parameter_name_in_cli}={parameter_value_in_work}")
+                else:
+                    if len(parameter_name_in_cli) == 2:
+                        # Short options (often denoted by a single hyphen and a single letter like -r)
+                        # are commonly written with a space between the option and its value
+                        args.append(
+                            f"{parameter_name_in_cli} {parameter_value_in_work}"
+                        )
+                    elif len(parameter_name_in_cli) > 2:
+                        # Long options (often denoted by two hyphens and a word like --recursive)
+                        # are commonly written with an equals sign between the option and its value
+                        args.append(
+                            f"{parameter_name_in_cli}={parameter_value_in_work}"
+                        )
 
     return args
 

--- a/workflow/lifecycle/execute.py
+++ b/workflow/lifecycle/execute.py
@@ -36,13 +36,10 @@ def function(work: Work) -> Work:
         assert isinstance(work.function, str), "missing function to execute"
         func: Callable[..., Any] = validate.function(work.function)
         arguments: List[str] = []
-        # Configure default values for the function
-        work = configure.defaults(func, work)
-        # Paramters to execute the function with
         parameters: Dict[str, Any] = work.parameters or {}
 
         if isinstance(func, click.Command):
-            arguments = configure.arguments(parameters)
+            arguments = configure.arguments(func, work)
             logger.info(
                 f"executing: {func.name}.main(args={arguments}, standalone_mode=False)"
             )


### PR DESCRIPTION
Since we are using the `.main` method to call a Click command (as opposed to `.callback` which skips the Click CLI), all defaults are already calculated. As such, we don't even need to use `configure.defaults`. Instead, I modified `configure.arguments` to correctly build the Click CLI command for the `.main` method usage, such that the Click CLI is used and all defaults, type conversions, and constraints and performed automatically by Click. This new modified `configure.arguments` function accounts for both `@click.argument` and `@click.option` types, as well as `is_flag=True` types. 