### PR TITLE
fix(daemons/transfer.py): fixed ids deletion

### DIFF
--- a/workflow/daemons/transfer.py
+++ b/workflow/daemons/transfer.py
@@ -239,7 +239,11 @@ def perform(
 
     if delete:
         logger.info(f"deleting {len(delete)} works from buckets")
-        http.buckets.delete_ids(delete)
+        if len(delete) > 100:
+            for batch in range(0, len(delete), 100):
+                http.buckets.delete_ids(delete[batch : batch + 100])
+        else:
+            http.buckets.delete_ids(delete)
     logger.info(f"transferred {transfered}, deleted {len(delete)} works")
     return {
         "transfered": transfered,


### PR DESCRIPTION
Reduced the amount of ids deleted at the same time due to URI too long.