### PR TITLE
fix(transfer daemon): `None` values in `delete` list causing HTTP request failures

### DIFF
--- a/workflow/daemons/transfer.py
+++ b/workflow/daemons/transfer.py
@@ -252,5 +252,6 @@ def perform(
         "deleted": len(delete),
     }
 
+
 if __name__ == "__main__":
     transfer.main(args=["--test-mode=True", "--log-level=DEBUG"], standalone_mode=False)

--- a/workflow/daemons/transfer.py
+++ b/workflow/daemons/transfer.py
@@ -237,6 +237,8 @@ def perform(
         delete = delete + [work["id"] for work in payload]
         transfered = len(payload)
 
+    delete = [item for item in delete if item is not None]
+
     if delete:
         logger.info(f"deleting {len(delete)} works from buckets")
         if len(delete) > 100:
@@ -249,7 +251,6 @@ def perform(
         "transfered": transfered,
         "deleted": len(delete),
     }
-
 
 if __name__ == "__main__":
     transfer.main(args=["--test-mode=True", "--log-level=DEBUG"], standalone_mode=False)

--- a/workflow/http/buckets.py
+++ b/workflow/http/buckets.py
@@ -137,6 +137,7 @@ class Buckets(Client):
             response: Response = session.delete(
                 url=f"{self.baseurl}/work", params={"ids": ids}
             )
+            logger.info(f"Response from Buckets: {response.text}")
             response.raise_for_status()
         return response.json()
 


### PR DESCRIPTION
## #137: Fix NoneType values in delete list causing HTTP request failures

### Description
This change addresses the issue where None values in the delete list caused an HTTP request failure with the message "NoneType' object is not iterable". The root cause was the lack of validation of the delete list before sending the request to the bucket deletion service.

### Changes
- Add check on the `delete` list to remove `None` values before sending HTTP request. 
- Add better logging in `Buckets` `delete_ids` function.
  - Before, the function just raised a status which is not descriptive enough to show the root cause of why the call failed.

#### Linked Issue: #137 

