### PR TITLE
fix(execute.py): fixing bad arguments for cli functions

### DIFF
--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -66,7 +66,7 @@ def test_cli_with_partials():
     work.function = "workflow.examples.function.cli"
     work.parameters = {"alpha": 5}
     work = execute.function(work)
-    results, products, plots = math(alpha=5, beta=2)
+    results, products, plots = math(alpha=5)
     assert work.results == results
     assert work.products == products
     assert work.plots == plots

--- a/workflow/examples/function.py
+++ b/workflow/examples/function.py
@@ -79,7 +79,6 @@ def worker(work: Work) -> Work:
 @click.option(
     "--alpha",
     "-a",
-    default=1.0,
     type=FirstOf(click.FLOAT, click.INT),
     required=True,
     help="A number.",
@@ -87,9 +86,9 @@ def worker(work: Work) -> Work:
 @click.option(
     "--beta",
     "-b",
-    default=2.0,
+    default=1,
     type=FirstOf(click.FLOAT, click.INT),
-    required=True,
+    required=False,
     help="Another number.",
 )
 @click.option(
@@ -100,7 +99,7 @@ def worker(work: Work) -> Work:
     default=False,
 )
 def cli(
-    alpha: Union[float, int], beta: Union[float, int], verbose: bool
+    alpha: Union[float, int], beta: Union[float, int] = 1.0, verbose: bool = False
 ) -> Tuple[Dict[str, float], List[str], List[str]]:
     """Click command for the math function."""
     results, products, plots = math(alpha, beta)

--- a/workflow/lifecycle/execute.py
+++ b/workflow/lifecycle/execute.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union, get_type_h
 import click
 
 from workflow.definitions.work import Work
-from workflow.lifecycle import configure
 from workflow.utils import validate
 from workflow.utils.logger import get_logger
 
@@ -35,7 +34,7 @@ def function(work: Work) -> Work:
     try:
         assert isinstance(work.function, str), "missing function to execute"
         func: Callable[..., Any] = validate.function(work.function)
-        arguments: List[str] = []
+        # arguments: List[str] = []
         parameters: Dict[str, Any] = work.parameters or {}
 
         if isinstance(func, click.Command):

--- a/workflow/lifecycle/execute.py
+++ b/workflow/lifecycle/execute.py
@@ -39,11 +39,13 @@ def function(work: Work) -> Work:
         parameters: Dict[str, Any] = work.parameters or {}
 
         if isinstance(func, click.Command):
-            arguments = configure.arguments(func, work)
-            logger.info(
-                f"executing: {func.name}.main(args={arguments}, standalone_mode=False)"
-            )
-            outcome = func.main(args=arguments, standalone_mode=False)
+            # arguments = configure.arguments(func, work)
+            # logger.info(
+            #     f"executing: {func.name}.main(args={arguments}, standalone_mode=False)"
+            # )
+            # outcome = func.main(args=arguments, standalone_mode=False)
+            # This will send the parameters as keyword arguments
+            outcome = func.callback(**parameters)  # type: ignore
         else:
             logger.info(
                 f"executing as python function: {func.__name__}(**{work.parameters})"


### PR DESCRIPTION
Instead of calling the func.main() with the reformated arguments, we call the func.callback() that accepts the Python formatted arguments.